### PR TITLE
Change to datasource.cs to handle Epson V550

### DIFF
--- a/src/TwainDotNet/DataSource.cs
+++ b/src/TwainDotNet/DataSource.cs
@@ -318,15 +318,15 @@ namespace TwainDotNet
                 NegotiateOrientation(settings);
             }
 
+            if (settings.Area != null)
+            {
+                NegotiateArea(settings);
+            }
+
             if (settings.Resolution != null)
             {
                 NegotiateColour(settings);
                 NegotiateResolution(settings);
-            }
-
-            if (settings.Area != null)
-            {
-                NegotiateArea(settings);
             }
 
             // Configure automatic rotation and image border detection


### PR DESCRIPTION
On the Epson V550 scanner the maximum resolution possible is a function of size of the area to be scanned. If the area to be scanned is 8.5inx11in the maximum resolution is 1184dpi. To make higher resolutions available, the area to be scanned needs to be set before the resolution is set. This is a simple change in datasource.cs
