### PR TITLE
Fix for AccessViolation on Windows 8.1 x64

### DIFF
--- a/src/TwainDotNet/DataSource.cs
+++ b/src/TwainDotNet/DataSource.cs
@@ -561,13 +561,16 @@ namespace TwainDotNet
                     Message.DisableDS,
                     userInterface);
 
-                result = Twain32Native.DsmIdentity(
-                    _applicationId,
-                    IntPtr.Zero,
-                    DataGroup.Control,
-                    DataArgumentType.Identity,
-                    Message.CloseDS,
-                    SourceId);
+                if (result != TwainResult.Failure)
+                {
+                    result = Twain32Native.DsmIdentity(
+                        _applicationId,
+                        IntPtr.Zero,
+                        DataGroup.Control,
+                        DataArgumentType.Identity,
+                        Message.CloseDS,
+                        SourceId);
+                }
             }
         }
     }


### PR DESCRIPTION
This is a fix for an error that was happening on Windows 8.1 x64.
I do not want to break any good behavior, but this fixed the problem.

This is the issue : 
https://github.com/tmyroadctfig/twaindotnet/issues/10#issuecomment-60686610%3E%20.%20%3Chttps://github.com/notifications/beacon/AI4_jmUi9RJWk4D9umgU9PAkiHzxVGb7ks5nHso5gaJpZM4BRfTT.gif

Please review it. Thank you!
