### PR TITLE
Update for issue #10

### DIFF
--- a/src/TwainDotNet/DataSource.cs
+++ b/src/TwainDotNet/DataSource.cs
@@ -551,26 +551,27 @@ namespace TwainDotNet
         {
             if (SourceId.Id != 0)
             {
-                UserInterface userInterface = new UserInterface();
-
-                TwainResult result = Twain32Native.DsUserInterface(
-                    _applicationId,
-                    SourceId,
-                    DataGroup.Control,
-                    DataArgumentType.UserInterface,
-                    Message.DisableDS,
-                    userInterface);
-
-                if (result != TwainResult.Failure)
+                try
                 {
-                    result = Twain32Native.DsmIdentity(
+                    UserInterface userInterface = new UserInterface();
+    
+                    TwainResult result = Twain32Native.DsUserInterface(
                         _applicationId,
-                        IntPtr.Zero,
+                        SourceId,
                         DataGroup.Control,
-                        DataArgumentType.Identity,
-                        Message.CloseDS,
-                        SourceId);
+                        DataArgumentType.UserInterface,
+                        Message.DisableDS,
+                        userInterface);
+    
+                    result = Twain32Native.DsmIdentity(
+                            _applicationId,
+                            IntPtr.Zero,
+                            DataGroup.Control,
+                            DataArgumentType.Identity,
+                            Message.CloseDS,
+                            SourceId);
                 }
+                catch {}
             }
         }
     }


### PR DESCRIPTION
Issue : https://github.com/tmyroadctfig/twaindotnet/issues/10
Removed the "if" condition and put everything in a "try/catch".

This problem happens only on some scanners.
The call to "Twain32Native.DsmIdentity" must be done even if the call to "Twain32Native.DsUserInterface" fails.
If the datasource is not completely closed after an error, we are not able to re-open it without re-initialising the Twain class.

Steps to reproduce :
 - Start a scan process without paper in the tray (Exception is thrown to notify there is not paper)
 - Restart a scan process without paper in the tray (Exception is thrown, Error opening datasource)