### PR TITLE
Incremental scanning progress in UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#twaindotnet
+# twaindotnet
 
 This project is based off the code from Thomas Scheidegger's excellent article on The Code Project: [http://www.codeproject.com/KB/dotnet/twaindotnet.aspx](http://www.codeproject.com/KB/dotnet/twaindotnet.aspx)
 
@@ -24,7 +24,7 @@ Also check out another alternative library: [NTwain](http://www.nuget.org/packag
   
   
 
-##TWAIN Resources
+## TWAIN Resources
   
   * [TWAIN 2.0 Spec](http://www.twain.org/docs/TWAIN_2_Spec.pdf)
   * [TWAIN header file](http://www.twain.org/devfiles/twain.h)
@@ -35,6 +35,7 @@ Also check out another alternative library: [NTwain](http://www.nuget.org/packag
 
 ### Brother
    * Brother DCP 7020
+   * Brother 9840 CDW
 
 ### Canon
    * Canon !CanoScan FB636U

--- a/src/TwainDotNet/DataSource.cs
+++ b/src/TwainDotNet/DataSource.cs
@@ -407,8 +407,8 @@ namespace TwainDotNet
         public bool Enable(ScanSettings settings)
         {
             UserInterface ui = new UserInterface();
-            ui.ShowUI = (short)(settings.ShowTwainUI ? 1 : 0);
-            ui.ModalUI = 1;
+            ui.ShowUI = (settings.ShowTwainUI ? TwainBool.True : TwainBool.False);
+            ui.ModalUI = TwainBool.True;
             ui.ParentHand = _messageHook.WindowHandle;
 
             var result = Twain32Native.DsUserInterface(

--- a/src/TwainDotNet/DataSourceManager.cs
+++ b/src/TwainDotNet/DataSourceManager.cs
@@ -187,7 +187,7 @@ namespace TwainDotNet
                 do
                 {
                     pendingTransfer.Count = 0;     // the Twain source will fill this in during DsPendingTransfer
-                    IntPtr hbitmap = IntPtr.Zero;  // the Twain source will allocate this buffer, and BitmapRenderer will deallocate it
+                    IntPtr hbitmap = IntPtr.Zero;
 
                     // Get the image info
                     ImageInfo imageInfo = new ImageInfo();

--- a/src/TwainDotNet/DataSourceManager.cs
+++ b/src/TwainDotNet/DataSourceManager.cs
@@ -21,6 +21,7 @@ namespace TwainDotNet
 
         public Identity ApplicationId { get; private set; }
         public DataSource DataSource { get; private set; }
+        public bool UseIncrementalMemoryXfer { get; set; } = true;
 
         public DataSourceManager(Identity applicationId, IWindowsMessageHook messageHook)
         {
@@ -139,7 +140,11 @@ namespace TwainDotNet
                     Exception exception = null;
                     try
                     {
-                        TransferPicturesIncremental();
+                        if (this.UseIncrementalMemoryXfer) {
+                            TransferPicturesIncremental();
+                        } else {
+                            TransferPictures();
+                        }
                     }
                     catch (Exception e)
                     {

--- a/src/TwainDotNet/TransferImageEventArgs.cs
+++ b/src/TwainDotNet/TransferImageEventArgs.cs
@@ -7,11 +7,13 @@ namespace TwainDotNet
     {
         public Bitmap Image { get; private set; }
         public bool ContinueScanning { get; set; }
+        public float PercentComplete { get; set; }
 
-        public TransferImageEventArgs(Bitmap image, bool continueScanning)
+        public TransferImageEventArgs(Bitmap image, bool continueScanning, float percentComplete)
         {
             this.Image = image;
             this.ContinueScanning = continueScanning;
+            this.PercentComplete = percentComplete;
         }
     }
 }

--- a/src/TwainDotNet/TwainDotNet.csproj
+++ b/src/TwainDotNet/TwainDotNet.csproj
@@ -30,6 +30,7 @@
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
     <DocumentationFile>bin\Debug\TwainDotNet.XML</DocumentationFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/TwainDotNet/TwainDotNet.csproj
+++ b/src/TwainDotNet/TwainDotNet.csproj
@@ -80,9 +80,12 @@
     <Compile Include="TwainNative\Frame.cs" />
     <Compile Include="TwainNative\ImageFileFormat.cs" />
     <Compile Include="TwainNative\ImageLayout.cs" />
+    <Compile Include="TwainNative\ImageMemXfer.cs" />
+    <Compile Include="TwainNative\Memory.cs" />
     <Compile Include="TwainNative\Orientation.cs" />
     <Compile Include="TwainNative\PageType.cs" />
     <Compile Include="TwainNative\PixelType.cs" />
+    <Compile Include="TwainNative\SetupMemXfer.cs" />
     <Compile Include="TwainNative\TransferMechanism.cs" />
     <Compile Include="TwainNative\TwainCapability.cs">
       <SubType>Code</SubType>

--- a/src/TwainDotNet/TwainDotNet.csproj
+++ b/src/TwainDotNet/TwainDotNet.csproj
@@ -30,7 +30,7 @@
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
     <DocumentationFile>bin\Debug\TwainDotNet.XML</DocumentationFile>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -68,6 +68,7 @@
     <Compile Include="TransferImageEventArgs.cs" />
     <Compile Include="TwainException.cs" />
     <Compile Include="TwainNative\AutoSize.cs" />
+    <Compile Include="TwainNative\TwainBool.cs" />
     <Compile Include="TwainNative\CapabilityArrayValue.cs" />
     <Compile Include="TwainNative\CapabilityEnumValue.cs" />
     <Compile Include="TwainNative\CapabilityOneValue.cs" />

--- a/src/TwainDotNet/TwainNative/ImageInfo.cs
+++ b/src/TwainDotNet/TwainNative/ImageInfo.cs
@@ -17,7 +17,7 @@ namespace TwainDotNet.TwainNative
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = 8)]
         public short[] BitsPerSample;
         public short BitsPerPixel;
-        public short Planar;
+        public TwainBool Planar;
         public short PixelType;
         public Compression Compression;
     }

--- a/src/TwainDotNet/TwainNative/ImageMemXfer.cs
+++ b/src/TwainDotNet/TwainNative/ImageMemXfer.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Runtime.InteropServices;
+
+namespace TwainDotNet.TwainNative
+{
+    /// <summary>
+    /// used with  DG_CONTROL / DAT_IMAGEMEMXFER / MSG_GET
+    /// typedef struct {
+    ///     TW_UINT16 Compression;
+    ///     TW_UINT32 BytesPerRow;
+    ///     TW_UINT32 Columns;
+    ///     TW_UINT32 Rows;
+    ///     TW_UINT32 XOffset;
+    ///     TW_UINT32 YOffset;
+    ///     TW_UINT32 BytesWritten;
+    ///     TW_MEMORY Memory;
+    /// } TW_IMAGEMEMXFER, FAR* pTW_IMAGEMEMXFER;
+    /// 
+    /// typedef struct {
+    ///     TW_UINT32 Flags;
+    ///     TW_UINT32 Length;
+    ///     TW_MEMREF TheMem;
+    /// } TW_MEMORY, FAR* pTW_MEMORY;
+    /// </summary>
+
+    [StructLayout(LayoutKind.Sequential, Pack = 2)]
+    public class ImageMemXfer
+    {
+        public Compression Compression;
+        public UInt32 BytesPerRow;
+        public UInt32 Columns;
+        public UInt32 Rows;
+        public UInt32 XOffset;
+        public UInt32 YOffset;
+        public UInt32 BytesWritten;
+        public Memory Memory;
+    }    
+
+}

--- a/src/TwainDotNet/TwainNative/Memory.cs
+++ b/src/TwainDotNet/TwainNative/Memory.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Runtime.InteropServices;
+
+namespace TwainDotNet.TwainNative
+{
+
+    // NOTE: Memory has to be a *struct* not *class* because it's embedded directly in other classes/structs
+    [StructLayout(LayoutKind.Sequential, Pack = 2)]
+    public struct Memory
+    {
+        public MemoryFlags Flags;
+        public UInt32 Length;
+        public IntPtr TheMem;
+    }
+
+    /// <summary>
+    /// Encodes which entity releases the buffer and how the buffer is referenced. 
+    /// (page 8-47)
+    /// 
+    /// TWMF_APPOWNS 0x1
+    /// TWMF_DSMOWNS 0x2
+    /// TWMF_DSOWNS 0x4
+    /// TWMF_POINTER 0x8
+    /// TWMF_HANDLE 0x10
+    /// </summary>
+    public enum MemoryFlags : ushort
+    {
+        AppOwns = 0x1,
+        DsmOwns = 0x2,
+        DsOwns = 0x4,
+        Pointer = 0x8,
+        Handle = 0x10,
+    }
+
+}

--- a/src/TwainDotNet/TwainNative/Memory.cs
+++ b/src/TwainDotNet/TwainNative/Memory.cs
@@ -25,7 +25,7 @@ namespace TwainDotNet.TwainNative
     /// TWMF_POINTER 0x8
     /// TWMF_HANDLE 0x10
     /// </summary>
-    public enum MemoryFlags : ushort
+    public enum MemoryFlags : uint   // UInt32
     {
         AppOwns = 0x1,
         DsmOwns = 0x2,

--- a/src/TwainDotNet/TwainNative/Message.cs
+++ b/src/TwainDotNet/TwainNative/Message.cs
@@ -51,6 +51,9 @@ namespace TwainDotNet.TwainNative
         Copy = 0x080A,
         AutoCaptureDir = 0x080B,
 
-        PassThru = 0x0901
+        PassThru = 0x0901,
+        RegisterCallback = 0x0902,
+
+        ResetAll = 0x0A01,
     }
 }

--- a/src/TwainDotNet/TwainNative/SetupMemXfer.cs
+++ b/src/TwainDotNet/TwainNative/SetupMemXfer.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Runtime.InteropServices;
+
+namespace TwainDotNet.TwainNative
+{
+    /// <summary>
+    /// used with  DG_CONTROL / DAT_SETUPMEMXFER / MSG_GET
+    /// typedef struct {
+    ///     TW_UINT32 MinBufSize /* Minimum buffer size in bytes */
+    ///     TW_UINT32 MaxBufSize /* Maximum buffer size in bytes */
+    ///     TW_UINT32 Preferred /* Preferred buffer size in bytes */
+    /// } TW_SETUPMEMXFER, FAR* pTW_SETUPMEMXFER;
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, Pack = 2)]
+    public class SetupMemXfer
+    {
+        public UInt32 MinBufSize;
+        public UInt32 MaxBufSize;
+        public UInt32 Preferred;
+    }
+}

--- a/src/TwainDotNet/TwainNative/Twain32Native.cs
+++ b/src/TwainDotNet/TwainNative/Twain32Native.cs
@@ -52,6 +52,12 @@ namespace TwainDotNet.TwainNative
         public static extern TwainResult DsImageTransfer([In, Out] Identity origin, [In] Identity dest, DataGroup dg, DataArgumentType dat, Message msg, ref IntPtr hbitmap);
 
         [DllImport("twain_32.dll", EntryPoint = "#1")]
+        public static extern TwainResult DsSetupMemXfer([In, Out] Identity origin, [In] Identity dest, DataGroup dg, DataArgumentType dat, Message msg, [In, Out] SetupMemXfer memxfer);
+
+        [DllImport("twain_32.dll", EntryPoint = "#1")]
+        public static extern TwainResult DsImageMemXfer([In, Out] Identity origin, [In] Identity dest, DataGroup dg, DataArgumentType dat, Message msg, [In, Out] ImageMemXfer memxfer);
+
+        [DllImport("twain_32.dll", EntryPoint = "#1")]
         public static extern TwainResult DsPendingTransfer([In, Out] Identity origin, [In] Identity dest, DataGroup dg, DataArgumentType dat, Message msg, [In, Out] PendingXfers pxfr);
 
         [DllImport("twain_32.dll", EntryPoint = "#1")]

--- a/src/TwainDotNet/TwainNative/TwainBool.cs
+++ b/src/TwainDotNet/TwainNative/TwainBool.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace TwainDotNet.TwainNative
+{
+    public enum TwainBool : short
+    {
+        True = 1,
+        False = 0,
+    }
+}

--- a/src/TwainDotNet/TwainNative/UserInterface.cs
+++ b/src/TwainDotNet/TwainNative/UserInterface.cs
@@ -14,12 +14,12 @@ namespace TwainDotNet.TwainNative
         /// <summary>
         /// TRUE if DS should bring up its UI
         /// </summary>
-        public short ShowUI;				// bool is strictly 32 bit, so use short
+        public TwainBool ShowUI;				// bool is strictly 32 bit, so use short
 
         /// <summary>
         /// For Mac only - true if the DS's UI is modal
         /// </summary>
-        public short ModalUI;
+        public TwainBool ModalUI;
 
         /// <summary>
         /// For windows only - Application window handle

--- a/src/TwainDotNet/Win32/BitmapInfoHeader.cs
+++ b/src/TwainDotNet/Win32/BitmapInfoHeader.cs
@@ -6,7 +6,7 @@ using System.Drawing;
 using System.Diagnostics;
 
 namespace TwainDotNet.Win32
-{    
+{
     [StructLayout(LayoutKind.Sequential, Pack = 2)]
     public class BitmapInfoHeader
     {
@@ -39,5 +39,4 @@ namespace TwainDotNet.Win32
                 ClrImportant);
         }
     }
-
 }

--- a/src/TwainDotNet/Win32/BitmapInfoHeader.cs
+++ b/src/TwainDotNet/Win32/BitmapInfoHeader.cs
@@ -39,4 +39,40 @@ namespace TwainDotNet.Win32
                 ClrImportant);
         }
     }
+
+
+    // Similar to BitmapInfoHeader "class" above, but BitmapRenderer MemoryXfer needs a "struct"    
+    // https://msdn.microsoft.com/en-us/library/windows/desktop/dd183376(v=vs.85).aspx
+    [StructLayout(LayoutKind.Sequential, Pack = 2)]
+    public struct BitmapInfoHeaderStruct
+    {
+        public int Size;
+        public int Width;
+        public int Height;
+        public short Planes;
+        public short BitCount;
+        public int Compression;
+        public int SizeImage;
+        public int XPelsPerMeter;
+        public int YPelsPerMeter;
+        public int ClrUsed;
+        public int ClrImportant;
+
+        public override string ToString() {
+            return string.Format(
+                "s:{0} w:{1} h:{2} p:{3} bc:{4} c:{5} si:{6} xpels:{7} ypels:{8} cu:{9} ci:{10}",
+                Size,
+                Width,
+                Height,
+                Planes,
+                BitCount,
+                Compression,
+                SizeImage,
+                XPelsPerMeter,
+                YPelsPerMeter,
+                ClrUsed,
+                ClrImportant);
+        }
+    }
+
 }

--- a/src/TwainDotNet/Win32/BitmapInfoHeader.cs
+++ b/src/TwainDotNet/Win32/BitmapInfoHeader.cs
@@ -6,7 +6,7 @@ using System.Drawing;
 using System.Diagnostics;
 
 namespace TwainDotNet.Win32
-{
+{    
     [StructLayout(LayoutKind.Sequential, Pack = 2)]
     public class BitmapInfoHeader
     {
@@ -24,41 +24,6 @@ namespace TwainDotNet.Win32
 
         public override string ToString()
         {
-            return string.Format(
-                "s:{0} w:{1} h:{2} p:{3} bc:{4} c:{5} si:{6} xpels:{7} ypels:{8} cu:{9} ci:{10}",
-                Size,
-                Width,
-                Height,
-                Planes,
-                BitCount,
-                Compression,
-                SizeImage,
-                XPelsPerMeter,
-                YPelsPerMeter,
-                ClrUsed,
-                ClrImportant);
-        }
-    }
-
-
-    // Similar to BitmapInfoHeader "class" above, but BitmapRenderer MemoryXfer needs a "struct"    
-    // https://msdn.microsoft.com/en-us/library/windows/desktop/dd183376(v=vs.85).aspx
-    [StructLayout(LayoutKind.Sequential, Pack = 2)]
-    public struct BitmapInfoHeaderStruct
-    {
-        public int Size;
-        public int Width;
-        public int Height;
-        public short Planes;
-        public short BitCount;
-        public int Compression;
-        public int SizeImage;
-        public int XPelsPerMeter;
-        public int YPelsPerMeter;
-        public int ClrUsed;
-        public int ClrImportant;
-
-        public override string ToString() {
             return string.Format(
                 "s:{0} w:{1} h:{2} p:{3} bc:{4} c:{5} si:{6} xpels:{7} ypels:{8} cu:{9} ci:{10}",
                 Size,

--- a/src/TwainDotNet/Win32/BitmapRenderer.cs
+++ b/src/TwainDotNet/Win32/BitmapRenderer.cs
@@ -100,5 +100,25 @@ namespace TwainDotNet.Win32
             Kernel32Native.GlobalUnlock(_dibHandle);
             Kernel32Native.GlobalFree(_dibHandle);
         }
+
+        public static Bitmap NewBitmapForImageInfo(TwainDotNet.TwainNative.ImageInfo imageInfo) 
+        {
+            return new Bitmap(imageInfo.ImageWidth,imageInfo.ImageLength,System.Drawing.Imaging.PixelFormat.Format24bppRgb);
+        }
+
+        public static void TransferPixels(Bitmap bitmap_dest, ref int pixel_number, TwainDotNet.TwainNative.ImageInfo imageInfo, TwainDotNet.TwainNative.ImageMemXfer memxfer_src)
+        {
+
+            int num_pixels_in_buffer = (int)((long)memxfer_src.Memory.Length / (long)(1 << imageInfo.BitsPerPixel));
+
+            // iterate through provided pixels, copying out pixel data
+            for ( int i=0 ; i < num_pixels_in_buffer ; i++ ) {
+                            
+                int x = pixel_number % bitmap_dest.Width;
+                int y = pixel_number / bitmap_dest.Width;
+                bitmap_dest.SetPixel(x,y,Color.Black);
+                pixel_number++;
+            }
+        }
     }
 }

--- a/src/TwainDotNet/Win32/BitmapRenderer.cs
+++ b/src/TwainDotNet/Win32/BitmapRenderer.cs
@@ -6,81 +6,9 @@ using log4net;
 
 namespace TwainDotNet.Win32
 {
-    public class BitmapRenderer : IDisposable
+    public static class BitmapRenderer
     {
-        /// <summary>
-        /// The logger for this class.
-        /// </summary>
         static ILog log = LogManager.GetLogger(typeof(BitmapRenderer));
-
-        IntPtr _dibHandle;
-        IntPtr _bitmapPointer;
-        IntPtr _pixelInfoPointer;
-        Rectangle _rectangle;
-        BitmapInfoHeader _bitmapInfo;
-
-        public BitmapRenderer(IntPtr dibHandle)
-        {
-            _dibHandle = dibHandle;
-            _bitmapPointer = Kernel32Native.GlobalLock(dibHandle);
-
-            _bitmapInfo = new BitmapInfoHeader();
-            Marshal.PtrToStructure(_bitmapPointer, _bitmapInfo);
-            log.Debug(_bitmapInfo.ToString());
-
-            _rectangle = new Rectangle();
-            _rectangle.X = _rectangle.Y = 0;
-            _rectangle.Width = _bitmapInfo.Width;
-            _rectangle.Height = _bitmapInfo.Height;
-
-            if (_bitmapInfo.SizeImage == 0)
-            {
-                _bitmapInfo.SizeImage = ((((_bitmapInfo.Width * _bitmapInfo.BitCount) + 31) & ~31) >> 3) * _bitmapInfo.Height;
-            }
-
-
-            // The following code only works on x86
-            Debug.Assert(Marshal.SizeOf(typeof(IntPtr)) == 4);
-
-            int pixelInfoPointer = _bitmapInfo.ClrUsed;
-            if ((pixelInfoPointer == 0) && (_bitmapInfo.BitCount <= 8))
-            {
-                pixelInfoPointer = 1 << _bitmapInfo.BitCount;
-            }
-
-            pixelInfoPointer = (pixelInfoPointer * 4) + _bitmapInfo.Size + _bitmapPointer.ToInt32();
-
-            _pixelInfoPointer = new IntPtr(pixelInfoPointer);
-        }
-
-        ~BitmapRenderer()
-        {
-            Dispose(false);
-        }
-
-        public Bitmap RenderToBitmap()
-        {
-            Bitmap bitmap = new Bitmap(_rectangle.Width, _rectangle.Height);
-
-            using (Graphics graphics = Graphics.FromImage(bitmap))
-            {
-                IntPtr hdc = graphics.GetHdc();
-
-                try
-                {
-                    Gdi32Native.SetDIBitsToDevice(hdc, 0, 0, _rectangle.Width, _rectangle.Height,
-                        0, 0, 0, _rectangle.Height, _pixelInfoPointer, _bitmapPointer, 0);
-                }
-                finally
-                {
-                    graphics.ReleaseHdc(hdc);
-                }
-            }
-
-            bitmap.SetResolution(PpmToDpi(_bitmapInfo.XPelsPerMeter), PpmToDpi(_bitmapInfo.YPelsPerMeter));
-
-            return bitmap;
-        }
 
         private static float PpmToDpi(double pixelsPerMeter)
         {
@@ -89,16 +17,63 @@ namespace TwainDotNet.Win32
             return (float)Math.Round(dotsPerInch, 2);
         }
 
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
+        
+        public static Bitmap NewBitmapFromHBitmap(IntPtr dibHandle) {
 
-        protected virtual void Dispose(bool disposing)
-        {
-            Kernel32Native.GlobalUnlock(_dibHandle);
-            Kernel32Native.GlobalFree(_dibHandle);
+            IntPtr _bitmapPointer;
+            IntPtr _pixelInfoPointer;
+            Rectangle _rectangle;
+            BitmapInfoHeader _bitmapInfo;
+            Bitmap bitmap;
+
+            _bitmapPointer = Kernel32Native.GlobalLock(dibHandle);
+            try {
+                _bitmapInfo = new BitmapInfoHeader();
+                Marshal.PtrToStructure(_bitmapPointer, _bitmapInfo);
+                log.Debug(_bitmapInfo.ToString());
+
+                _rectangle = new Rectangle();
+                _rectangle.X = _rectangle.Y = 0;
+                _rectangle.Width = _bitmapInfo.Width;
+                _rectangle.Height = _bitmapInfo.Height;
+
+                if (_bitmapInfo.SizeImage == 0) {
+                    _bitmapInfo.SizeImage = ((((_bitmapInfo.Width * _bitmapInfo.BitCount) + 31) & ~31) >> 3) * _bitmapInfo.Height;
+                }
+
+
+                // compute the offset to the pixel info, which follows the bitmap info header
+                { 
+                    // The following code only works on x86
+                    Debug.Assert(Marshal.SizeOf(typeof(IntPtr)) == 4);                
+                    int pixelInfoPointer = _bitmapInfo.ClrUsed;
+                    if ((pixelInfoPointer == 0) && (_bitmapInfo.BitCount <= 8)) {
+                        pixelInfoPointer = 1 << _bitmapInfo.BitCount;
+                    }
+                    pixelInfoPointer = (pixelInfoPointer * 4) + _bitmapInfo.Size + _bitmapPointer.ToInt32();
+                    _pixelInfoPointer = new IntPtr(pixelInfoPointer);
+                }
+
+                // render to bitmap
+                bitmap = new Bitmap(_rectangle.Width, _rectangle.Height);
+
+                using (Graphics graphics = Graphics.FromImage(bitmap)) {
+                    IntPtr hdc = graphics.GetHdc();
+
+                    try {
+                        Gdi32Native.SetDIBitsToDevice(hdc, 0, 0, _rectangle.Width, _rectangle.Height,
+                            0, 0, 0, _rectangle.Height, _pixelInfoPointer, _bitmapPointer, 0);
+                    }
+                    finally {
+                        graphics.ReleaseHdc(hdc);
+                    }
+                }
+
+                bitmap.SetResolution(PpmToDpi(_bitmapInfo.XPelsPerMeter), PpmToDpi(_bitmapInfo.YPelsPerMeter));
+            } finally {
+                Kernel32Native.GlobalUnlock(dibHandle);
+            }
+            return bitmap;
         }
 
         public static Bitmap NewBitmapForImageInfo(TwainDotNet.TwainNative.ImageInfo imageInfo) 

--- a/src/TwainDotNet/Win32/BitmapRenderer.cs
+++ b/src/TwainDotNet/Win32/BitmapRenderer.cs
@@ -103,39 +103,26 @@ namespace TwainDotNet.Win32
 
         public static Bitmap NewBitmapForImageInfo(TwainDotNet.TwainNative.ImageInfo imageInfo) 
         {
-            return new Bitmap(imageInfo.ImageWidth,imageInfo.ImageLength,System.Drawing.Imaging.PixelFormat.Format24bppRgb);
-        }
-
-        public static void TransferPixels_Test(Bitmap bitmap_dest, ref int pixel_number, TwainDotNet.TwainNative.ImageInfo imageInfo, TwainDotNet.TwainNative.ImageMemXfer memxfer_src)
-        {
-            
-            int bytes_per_pixel = imageInfo.BitsPerPixel / 8;
-            int num_pixels_in_buffer = (int)memxfer_src.BytesWritten / bytes_per_pixel;
-
-            // iterate through provided pixels, copying out pixel data
-            for ( int i=0 ; i < num_pixels_in_buffer ; i++ ) {
-                            
-                int x = pixel_number % bitmap_dest.Width;
-                int y = pixel_number / bitmap_dest.Width;
-                bitmap_dest.SetPixel(x,y,Color.Red);
-                pixel_number++;
+            var bitmap = new Bitmap(imageInfo.ImageWidth,imageInfo.ImageLength,System.Drawing.Imaging.PixelFormat.Format24bppRgb);
+            using (Graphics graphics = Graphics.FromImage(bitmap)) {
+                graphics.Clear(Color.White);
             }
+            return bitmap;
         }
 
-
-
-
-        public static unsafe void TransferPixels(Bitmap bitmap_dest, ref int pixel_number, TwainDotNet.TwainNative.ImageInfo imageInfo, TwainDotNet.TwainNative.ImageMemXfer memxfer_src) {
+        public static unsafe void TransferPixels(Bitmap bitmap_dest, 
+            TwainDotNet.TwainNative.ImageInfo imageInfo, TwainDotNet.TwainNative.ImageMemXfer memxfer_src) {
             BitmapInfoHeaderStruct bitmapInfo = new BitmapInfoHeaderStruct();
             bitmapInfo.Width = (int) memxfer_src.Columns;
             bitmapInfo.Height = - (int) memxfer_src.Rows;
-            bitmapInfo.Size = sizeof(BitmapInfoHeaderStruct);
-            bitmapInfo.BitCount = imageInfo.BitsPerPixel;    
+            bitmapInfo.Size = sizeof(BitmapInfoHeaderStruct);            
             bitmapInfo.Planes = 1;
-            bitmapInfo.SizeImage = 0;            
-
+            bitmapInfo.SizeImage = 0;
+            bitmapInfo.BitCount = imageInfo.BitsPerPixel;   // this might not work in all cases            
 
             using (Graphics graphics = Graphics.FromImage(bitmap_dest)) {
+                
+
                 IntPtr hdc = graphics.GetHdc();
                 try {
                     Gdi32Native.SetDIBitsToDevice(

--- a/src/TwainDotNet/Win32/BitmapRenderer.cs
+++ b/src/TwainDotNet/Win32/BitmapRenderer.cs
@@ -143,40 +143,5 @@ namespace TwainDotNet.Win32
             }
 
         }
-
-
-        // https://msdn.microsoft.com/en-us/library/windows/desktop/dd183376(v=vs.85).aspx
-        [StructLayout(LayoutKind.Sequential, Pack = 2)]
-        public struct  BitmapInfoHeaderStruct
-        {
-            public int Size;
-            public int Width;
-            public int Height;
-            public short Planes;
-            public short BitCount;
-            public int Compression;
-            public int SizeImage;
-            public int XPelsPerMeter;
-            public int YPelsPerMeter;
-            public int ClrUsed;
-            public int ClrImportant;
-
-            public override string ToString() {
-                return string.Format(
-                    "s:{0} w:{1} h:{2} p:{3} bc:{4} c:{5} si:{6} xpels:{7} ypels:{8} cu:{9} ci:{10}",
-                    Size,
-                    Width,
-                    Height,
-                    Planes,
-                    BitCount,
-                    Compression,
-                    SizeImage,
-                    XPelsPerMeter,
-                    YPelsPerMeter,
-                    ClrUsed,
-                    ClrImportant);
-            }
-        }
-
     }
 }

--- a/src/TwainDotNet/Win32/BitmapRenderer.cs
+++ b/src/TwainDotNet/Win32/BitmapRenderer.cs
@@ -108,15 +108,15 @@ namespace TwainDotNet.Win32
 
         public static void TransferPixels(Bitmap bitmap_dest, ref int pixel_number, TwainDotNet.TwainNative.ImageInfo imageInfo, TwainDotNet.TwainNative.ImageMemXfer memxfer_src)
         {
-
-            int num_pixels_in_buffer = (int)((long)memxfer_src.Memory.Length / (long)(1 << imageInfo.BitsPerPixel));
+            int bytes_per_pixel = imageInfo.BitsPerPixel / 8;
+            int num_pixels_in_buffer = (int)memxfer_src.BytesWritten / bytes_per_pixel;
 
             // iterate through provided pixels, copying out pixel data
             for ( int i=0 ; i < num_pixels_in_buffer ; i++ ) {
                             
                 int x = pixel_number % bitmap_dest.Width;
                 int y = pixel_number / bitmap_dest.Width;
-                bitmap_dest.SetPixel(x,y,Color.Black);
+                bitmap_dest.SetPixel(x,y,Color.Red);
                 pixel_number++;
             }
         }

--- a/src/TwainDotNet/Win32/BitmapRenderer.cs
+++ b/src/TwainDotNet/Win32/BitmapRenderer.cs
@@ -106,8 +106,9 @@ namespace TwainDotNet.Win32
             return new Bitmap(imageInfo.ImageWidth,imageInfo.ImageLength,System.Drawing.Imaging.PixelFormat.Format24bppRgb);
         }
 
-        public static void TransferPixels(Bitmap bitmap_dest, ref int pixel_number, TwainDotNet.TwainNative.ImageInfo imageInfo, TwainDotNet.TwainNative.ImageMemXfer memxfer_src)
+        public static void TransferPixels_Test(Bitmap bitmap_dest, ref int pixel_number, TwainDotNet.TwainNative.ImageInfo imageInfo, TwainDotNet.TwainNative.ImageMemXfer memxfer_src)
         {
+            
             int bytes_per_pixel = imageInfo.BitsPerPixel / 8;
             int num_pixels_in_buffer = (int)memxfer_src.BytesWritten / bytes_per_pixel;
 
@@ -120,5 +121,75 @@ namespace TwainDotNet.Win32
                 pixel_number++;
             }
         }
+
+
+
+
+        public static unsafe void TransferPixels(Bitmap bitmap_dest, ref int pixel_number, TwainDotNet.TwainNative.ImageInfo imageInfo, TwainDotNet.TwainNative.ImageMemXfer memxfer_src) {
+            BitmapInfoHeaderStruct bitmapInfo = new BitmapInfoHeaderStruct();
+            bitmapInfo.Width = (int) memxfer_src.Columns;
+            bitmapInfo.Height = - (int) memxfer_src.Rows;
+            bitmapInfo.Size = sizeof(BitmapInfoHeaderStruct);
+            bitmapInfo.BitCount = imageInfo.BitsPerPixel;    
+            bitmapInfo.Planes = 1;
+            bitmapInfo.SizeImage = 0;            
+
+
+            using (Graphics graphics = Graphics.FromImage(bitmap_dest)) {
+                IntPtr hdc = graphics.GetHdc();
+                try {
+                    Gdi32Native.SetDIBitsToDevice(
+                        hdc, 
+                        (int)memxfer_src.XOffset, 
+                        (int)memxfer_src.YOffset, 
+                        (int)memxfer_src.Columns, 
+                        (int)memxfer_src.Rows,
+                        0, 0, 0, 
+                        (int)memxfer_src.Rows,
+                        memxfer_src.Memory.TheMem, 
+                        new IntPtr(&bitmapInfo), 
+                        0);
+                }
+                finally {
+                    graphics.ReleaseHdc(hdc);
+                }
+            }
+
+        }
+
+
+        // https://msdn.microsoft.com/en-us/library/windows/desktop/dd183376(v=vs.85).aspx
+        [StructLayout(LayoutKind.Sequential, Pack = 2)]
+        public struct  BitmapInfoHeaderStruct
+        {
+            public int Size;
+            public int Width;
+            public int Height;
+            public short Planes;
+            public short BitCount;
+            public int Compression;
+            public int SizeImage;
+            public int XPelsPerMeter;
+            public int YPelsPerMeter;
+            public int ClrUsed;
+            public int ClrImportant;
+
+            public override string ToString() {
+                return string.Format(
+                    "s:{0} w:{1} h:{2} p:{3} bc:{4} c:{5} si:{6} xpels:{7} ypels:{8} cu:{9} ci:{10}",
+                    Size,
+                    Width,
+                    Height,
+                    Planes,
+                    BitCount,
+                    Compression,
+                    SizeImage,
+                    XPelsPerMeter,
+                    YPelsPerMeter,
+                    ClrUsed,
+                    ClrImportant);
+            }
+        }
+
     }
 }

--- a/src/TwainDotNet/Win32/Gdi32Native.cs
+++ b/src/TwainDotNet/Win32/Gdi32Native.cs
@@ -12,6 +12,10 @@ namespace TwainDotNet.Win32
             int xsrc, int ysrc, int start, int lines, IntPtr bitsptr, IntPtr bmiptr, int color);
 
         [DllImport("gdi32.dll", ExactSpelling = true)]
+        public static extern int SetDIBitsToDevice(IntPtr hdc, int xdst, int ydst, int width, int height,
+            int xsrc, int ysrc, int start, int lines, IntPtr bitsptr, [In] BitmapInfoHeader bmiptr, int color);
+
+        [DllImport("gdi32.dll", ExactSpelling = true)]
         public static extern bool DeleteObject(IntPtr hObject);
     }
 }


### PR DESCRIPTION
TLDR - This causes scanned image data to appear incrementally, instead of only once the scan is done.

This adds a new DataSourceManager.UseIncrementalMemoryXfer boolean flag (default false), which when set to true causes TwainDotNet to use new code for incremental TWAIN ImageMemXfer, instead of the existing blocking ImageNativeXfer.  

Currently the new Incremental mode only supports TWAIN 1 bpp and 24 bpp RGB image data. It does not support 8bpp greyscale,  40bpp CMYK, or Planar RRR-GGG-BBB formats, because these formats are not supported by Gdi32Native.SetDIBitsToDevice. These formats could either be supported via other conversion means, or the code could be changed to fallback to ImageNativeXfer for unsupported formats.

This also fixes a memory leak in DataSourcemanager.TransferPictures(), where hbitmap is not deallocated if a TWAIN failure code causes an early-exit before the IDisposable BitmapRenderer was created to manage it's lifetime. The hbitmap to Bitmap conversion is now a static method, and TransferPictures() closes lifetime on hbitmap in a finally clause. 

It also adds a TwainBool enum, because this added tests for twain boolean values, and it felt a bit error prone to just use "1" and "0" numbers. 