### PR TITLE
Resolution for Issue #23 Error Opening Data Source

### DIFF
--- a/src/TwainDotNet/DataSource.cs
+++ b/src/TwainDotNet/DataSource.cs
@@ -302,7 +302,7 @@ namespace TwainDotNet
         {
             OpenSource();
 
-            if (settings.AbortWhenNoPaperDetectable && !PaperDetectable)
+            if (settings.AbortWhenNoPaperDetectable || !PaperDetectable)
                 throw new FeederEmptyException();
 
             // Set whether or not to show progress window


### PR DESCRIPTION
Modified the condition 
if (settings.AbortWhenNoPaperDetectable && !PaperDetectable) 
to 
if (settings.AbortWhenNoPaperDetectable || !PaperDetectable)
Since settings.AbortWhenNoPaperDetectable is always coming as false even if there is no paper in the feeder